### PR TITLE
V0.2.14 branch

### DIFF
--- a/js/actor.mjs
+++ b/js/actor.mjs
@@ -1,0 +1,80 @@
+
+import { isTheGM, MODULENAME } from "./utils.mjs";
+import { SpritesheetGenerator } from "./spritesheets.mjs"; 
+
+
+
+export function _getTokenChangesForSpritesheet(src) {
+  const spritesheetSettings = SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS[src];
+  if (spritesheetSettings === undefined) return {};
+
+  const data = {...spritesheetSettings};
+  data.spritesheet = true;
+  const updates = {
+    "flags.pokemon-assets": data,
+    "texture.src": src,
+  };
+  if ("scale" in data || "anchor" in data) {
+    data.scale ??= 1;
+    data.anchor ??= 0.5
+    if (game.system.id == "ptr2e") updates["flags.ptr2e.autoscale"] = false;
+    if (game.system.id == "ptu") updates["flags.ptu.autoscale"] = false;
+    updates["texture.scaleX"] = updates["texture.scaleY"] = data.scale;
+    updates["texture.fit"] = "width";
+    updates["texture.anchorX"] = 0.5;
+    updates["texture.anchorY"] = data.anchor;
+    delete data.scale;
+    delete data.anchor;
+  }
+  return updates;
+}
+
+
+
+function OnPreUpdateActor(actor, updates) {
+  if (actor.img == updates.img || !updates.img) return;
+
+  // the image has changed!
+  const src = updates.img.replace("modules/pokemon-assets/img/trainers-profile/", "modules/pokemon-assets/img/trainers-overworld/");
+  const spritesheet = SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS[src];
+  if (!spritesheet) return;
+
+  foundry.utils.mergeObject(updates, {
+    "prototypeToken": _getTokenChangesForSpritesheet(src),
+  });
+}
+
+function OnPreCreateActor(actor, data) {
+  const img = data.img ?? actor.img;
+  if (!img || !img.includes("modules/pokemon-assets/img/trainers-profile/")) return;
+
+  const src = img.replace("modules/pokemon-assets/img/trainers-profile/", "modules/pokemon-assets/img/trainers-overworld/");
+  const spritesheet = SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS[src];
+  if (!spritesheet) return;
+
+  foundry.utils.mergeObject(data, {
+    "prototypeToken": _getTokenChangesForSpritesheet(src),
+  });
+}
+
+function OnCreateActor(actor) {
+  if (!isTheGM()) return;
+  if (!actor.img.includes("modules/pokemon-assets/img/trainers-profile/")) return;
+  
+  const src = actor.img.replace("modules/pokemon-assets/img/trainers-profile/", "modules/pokemon-assets/img/trainers-overworld/");
+  const spritesheet = SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS[src];
+  if (!spritesheet) return;
+
+  actor.update({
+    "prototypeToken": _getTokenChangesForSpritesheet(src),
+  });
+}
+
+
+export function register() {
+  if (game.settings.get(MODULENAME, "autoMatchTokenSprite")) {
+    Hooks.on("preUpdateActor", OnPreUpdateActor);
+    Hooks.on("preCreateActor", OnPreCreateActor);
+    Hooks.on("createActor", OnCreateActor);
+  }
+}

--- a/js/main.mjs
+++ b/js/main.mjs
@@ -1,6 +1,7 @@
 
 import * as settings from "./settings.mjs";
 import * as preload from "./preload.mjs";
+import * as actor from "./actor.mjs";
 import * as audio from "./audio.mjs";
 import * as controls from "./controls.mjs";
 import * as dialog from "./dialog.mjs";
@@ -16,6 +17,7 @@ import * as socket from "./socket.mjs";
 Hooks.on("init", ()=>{
   for (const m of [settings,
     preload,
+    actor,
     audio,
     controls,
     dialog,

--- a/js/settings.mjs
+++ b/js/settings.mjs
@@ -27,7 +27,7 @@ export function register() {
 		default: true,
 		type: Boolean,
 		scope: "world",
-		requiresReload: false,
+		requiresReload: true,
 		config: true,
 		hint: "Avoid blurring the canvas and tokens when they get scaled up."
 	});
@@ -42,6 +42,16 @@ export function register() {
 		hint: "Preload audio playlist when switching to a scene, and when a combat is completed, move to the next track."
 	});
 
+  game.settings.register(MODULENAME, "autoTrainerImage", {
+		name: "Auto Set Trainer Profile Image",
+		default: true,
+		type: Boolean,
+		scope: "world",
+		requiresReload: false,
+		config: true,
+		hint: "Automatically set the profile image of a Trainer to a random trainer upon creation."
+	});
+
   game.settings.register(MODULENAME, "autoSetTokenSprite", {
 		name: "Auto Set Token Sprite",
 		default: true,
@@ -50,6 +60,16 @@ export function register() {
 		requiresReload: false,
 		config: true,
 		hint: "Automatically set the token sprite of a Pokemon to one defined in this module when the actor is created."
+	});
+
+  game.settings.register(MODULENAME, "autoMatchTokenSprite", {
+		name: "Auto Match Token Sprite",
+		default: true,
+		type: Boolean,
+		scope: "world",
+		requiresReload: false,
+		config: true,
+		hint: "Automatically set the token sprite of a Trainer to the matching overworld spritesheet when you set the trainer's profile sprite."
 	});
 
 	game.settings.register(MODULENAME, "autoOverrideMegaEvolutionSprite", {

--- a/js/system-specific/ptr2e.mjs
+++ b/js/system-specific/ptr2e.mjs
@@ -274,7 +274,11 @@ function HasMoveFunction(slug) {
   };
 }
 
-
+// re-prepare the token document on render? to account for weird size issues
+function Token_applyRenderFlags(wrapped, flags) {
+  TokenDocument.prototype.prepareData.apply(this.document);
+  wrapped(flags);
+}
 
 /**
  * Overridden for the purposes of mega evolutions
@@ -345,6 +349,7 @@ export function register() {
 
   Hooks.on("preCreateToken", OnPreCreateToken);
   libWrapper.register(MODULENAME, "game.ptr.util.image.createFromSpeciesData", ImageResolver_createFromSpeciesData, "WRAPPER");
+  libWrapper.register(MODULENAME, "CONFIG.Token.objectClass.prototype._applyRenderFlags", Token_applyRenderFlags, "WRAPPER");
 
   libWrapper.register(MODULENAME, "CONFIG.ActiveEffect.dataModels.passive.schema.fields.changes.element.types.token-alterations.model.prototype.apply", TokenAlterations_apply, "WRAPPER");
   libWrapper.register(MODULENAME, "CONFIG.Token.documentClass.prototype.prepareDerivedData", TokenDocument_prepareDerivedData, "WRAPPER");

--- a/js/system-specific/ptu.mjs
+++ b/js/system-specific/ptu.mjs
@@ -190,7 +190,7 @@ function TokenImageRuleElement_afterPrepareData(wrapped, ...args) {
   if (game.settings.get(MODULENAME, "autoOverrideMegaEvolutionSprite")) {
     // check if this is a mega evolution that we have a sprite for
     const foundMegaEvo = (()=>{
-      const basename = this.value.substring(this.value.lastIndexOf("/"), this.value.lastIndexOf("."));
+      const basename = this.value.substring(this.value.lastIndexOf("/")+1, this.value.lastIndexOf("."));
       if (!basename) return false;
 
       const alternateForm = basename.substring(basename.indexOf("_"));

--- a/js/system-specific/ptu.mjs
+++ b/js/system-specific/ptu.mjs
@@ -1,5 +1,6 @@
 import { early_isGM, isTheGM, MODULENAME } from "../utils.mjs";
 import { SpritesheetGenerator } from "../spritesheets.mjs"; 
+import { _getTokenChangesForSpritesheet } from "../actor.mjs";
 
 /**
  * A Chat Message listener, that should only be run on the GM's client
@@ -110,11 +111,7 @@ function _getPrototypeTokenUpdates(actor, species, formOverride=null) {
   if (!src) return {};
   
   const updates = {
-    "prototypeToken.texture.src": src,
-    "prototypeToken.flags.pokemon-assets": {
-      spritesheet: true,
-      ...SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS[src],
-    }
+    "prototypeToken": _getTokenChangesForSpritesheet(src),
   };
   return updates;
 }
@@ -125,14 +122,56 @@ function _getPrototypeTokenUpdates(actor, species, formOverride=null) {
  * @param {*} actor
  * @returns 
  */
-function OnPreCreateActor(actor) {
+function OnPreCreateActor(actor, data) {
   if (!game.settings.get(MODULENAME, "autoSetTokenSprite")) return;
-  if (actor.type !== "pokemon") return;
-  const species = actor.items.find(i=>i.type === "species");
-  if (!species) return;
 
-  const updates = _getPrototypeTokenUpdates(actor, species);
-  actor.updateSource(updates);
+  if (actor.type === "pokemon") {
+    const species = actor.items.find(i=>i.type === "species");
+    if (!species) return;
+  
+    const updates = _getPrototypeTokenUpdates(actor, species);
+    actor.updateSource(updates);
+    return;
+  }
+
+  if (actor.type === "character") {
+    if (!game.settings.get(MODULENAME, "autoTrainerImage")) return;
+    if (!(data.img ?? actor.img ?? "icons/svg/mystery-man.svg").includes("icons/svg/mystery-man.svg")) return;
+  
+    const img = (()=>{
+      let possibleImages = Object.keys(SpritesheetGenerator.CONFIGURED_SHEET_SETTINGS).filter(k=>k.startsWith("modules/pokemon-assets/img/trainers-overworld/trainer_")).map(k=>k.substring(46));
+      const sex = (()=>{
+        const sexSet = data?.system?.sex ?? actor?.system?.sex;
+        if (!sexSet) return "";
+        if (["f", "female", "girl", "woman", "lady", "she", "feminine", "fem", "dame", "gal", "lass", "lassie", "madam", "maiden", "doll", "mistress"].includes(sexSet.toLowerCase().trim())) {
+          return "_f_";
+        }
+        return "_m_";
+      })();
+      possibleImages = possibleImages.filter(k=>k.includes(sex));
+      // TODO: maybe filter also based on some mapping of classes to the official pokemon trainer classes?
+      if (possibleImages.length === 0) return null;
+      return possibleImages[~~(Math.random() * possibleImages.length)];
+    })();
+    if (!img) return;
+
+    const updates = {
+      img: `modules/pokemon-assets/img/trainers-profile/${img}`,
+      prototypeToken: _getTokenChangesForSpritesheet(`modules/pokemon-assets/img/trainers-overworld/${img}`),
+    }
+    foundry.utils.mergeObject(data, foundry.utils.deepClone(updates));
+    actor.updateSource(updates);
+    return;
+  }
+  
+}
+
+// Disable the autoscaling
+function OnPreCreateToken(token, data) {
+  if (!game.settings.get(MODULENAME, "autoSetTokenSprite")) return;
+  token.updateSource({
+    "flags.ptu.autoscale": false,
+  });
 }
 
 /**
@@ -407,6 +446,7 @@ export function register() {
     Hooks.on("createChatMessage", OnCreateChatMessage);
   }
   Hooks.on("preCreateActor", OnPreCreateActor);
+  Hooks.on("preCreateToken", OnPreCreateToken);
   Hooks.on("createToken", OnCreateToken);
   Hooks.on("createItem", OnCreateItem);
 

--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/righthandofvecna"
     }
   ],
-  "version": "0.2.13",
+  "version": "0.2.14",
   "compatibility": {
     "minimum": "12",
     "verified": "12.331"
@@ -52,5 +52,5 @@
 	"socket": true,
   "url": "https://github.com/righthandofvecna/pokemon-assets",
   "manifest": "https://github.com/righthandofvecna/pokemon-assets/releases/latest/download/module.json",
-  "download": "https://github.com/righthandofvecna/pokemon-assets/releases/download/v0.2.13/module.zip"
+  "download": "https://github.com/righthandofvecna/pokemon-assets/releases/download/v0.2.14/module.zip"
 }


### PR DESCRIPTION
- Auto-set trainer sprites on creation, and update the token sprite to match the trainer profile image (both PTR1e and PTR2e)
- Add support for mega evolutions and other temporary forms (for PTR2e)
- Add a workaround for dynamax token resizing (for PTR2e)