### PR TITLE
V0.7.10 branch

### DIFF
--- a/js/configs/tile-config.mjs
+++ b/js/configs/tile-config.mjs
@@ -8,6 +8,7 @@ async function TileConfig_preparePartContext(wrapped, partId, context, options) 
   if (partId === "puzzle") {
     const tile = context.document;
     const pa = tile?.flags?.[MODULENAME] ?? {};
+    pa.visibleDistance ??= "";
     pa.isCustomSound = pa.interactionSound && !Object.keys(SOUNDS).some(v=>v === pa.interactionSound);
     pa.sounds = SOUNDS;
     pa.scriptField = new StringField({}, { parent: { fieldPath: `flags.${MODULENAME}.script` } });

--- a/js/placeables/token.mjs
+++ b/js/placeables/token.mjs
@@ -624,10 +624,10 @@ export function register() {
        * 
        */
       async _drawIndicators() {
+        if (!this.indicators) return;
         this.indicators.renderable = false;
 
-        // clear caught indicator
-        this.indicators.removeChildren().forEach(c => c.destroy());
+        const allIndicators = [];
         
         if (game.settings.get(MODULENAME, "showCaughtIndicator")) {
           const logic = game?.modules?.get(MODULENAME)?.api?.logic;
@@ -644,11 +644,11 @@ export function register() {
           if (caught === true) {
             const tex = await foundry.canvas.loadTexture(`modules/${MODULENAME}/img/ui/caught-indicator.png`, {fallback: "icons/svg/hazard.svg"});
             const icon = new PIXI.Sprite(tex);
-            this.indicators.addChild(icon);
+            allIndicators.push(icon);
           } else if (caught === false) {
             const tex = await foundry.canvas.loadTexture(`modules/${MODULENAME}/img/ui/uncaught-indicator.png`, {fallback: "icons/svg/hazard.svg"});
             const icon = new PIXI.Sprite(tex);
-            this.indicators.addChild(icon);
+            allIndicators.push(icon);
           }
         }
         
@@ -660,7 +660,7 @@ export function register() {
           if (shiny) {
             const tex = await foundry.canvas.loadTexture(`modules/${MODULENAME}/img/ui/shiny-indicator.png`, {fallback: "icons/svg/explosion.svg"});
             const icon = new PIXI.Sprite(tex);
-            this.indicators.addChild(icon);
+            allIndicators.push(icon);
           }
         }
 
@@ -670,10 +670,13 @@ export function register() {
           if (uncatchable) {
             const tex = await foundry.canvas.loadTexture(`modules/${MODULENAME}/img/ui/uncatchable-indicator.png`, {fallback: "icons/svg/hazard.svg"});
             const icon = new PIXI.Sprite(tex);
-            this.indicators.addChild(icon);
+            allIndicators.push(icon);
           }
         }
 
+        // clear indicators and readd them
+        this.indicators.removeChildren().forEach(c => c.destroy());
+        allIndicators.forEach(icon => this.indicators.addChild(icon));
         this.indicators.sortChildren();
         this.indicators.renderable = true;
         this.renderFlags.set({refreshIndicators: true});

--- a/js/system-specific/pokerole.mjs
+++ b/js/system-specific/pokerole.mjs
@@ -349,7 +349,7 @@ export function register() {
   api.logic.ActorCry ??= ActorCry;
   api.logic.ActorShiny ??= (actor)=>actor?.system?.shiny ?? false;
 
-  api.logic.isPokemon ??= (actor)=>isActorPokemon(actor);
+  api.logic.isPokemon ??= (token)=>isActorPokemon(token?.actor);
 
   api.scripts ??= {};
   api.scripts.HasMoveFunction ??= HasMoveFunction;

--- a/js/version.mjs
+++ b/js/version.mjs
@@ -1,1 +1,1 @@
-export const VERSION = "0.7.9";
+export const VERSION = "0.7.10";

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "flags": {}
     }
   ],
-  "version": "0.7.9",
+  "version": "0.7.10",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -96,6 +96,6 @@
   "socket": true,
   "url": "https://github.com/righthandofvecna/pokemon-assets",
   "manifest": "https://github.com/righthandofvecna/pokemon-assets/releases/latest/download/module.json",
-  "download": "https://github.com/righthandofvecna/pokemon-assets/releases/download/v0.7.9/module.zip",
+  "download": "https://github.com/righthandofvecna/pokemon-assets/releases/download/v0.7.10/module.zip",
   "flags": {}
 }

--- a/templates/tile-settings.hbs
+++ b/templates/tile-settings.hbs
@@ -31,6 +31,13 @@
       </div>
     </div>
     <div class="form-group">
+      <label>Visible Distance</label>
+      <div class="form-fields">
+        <input type="number" name="flags.pokemon-assets.visibleDistance" value="{{pa.visibleDistance}}" min="0" step="1" />
+      </div>
+      <p class="hint">The number of grid spaces away the tile's texture can be seen from. Unset for infinite, 0 for always invisible.</p>
+    </div>
+    <div class="form-group">
       <label>Interaction Sound</label>
       <div class="form-fields">
         <select name="flags.pokemon-assets.interactionSound">


### PR DESCRIPTION
- Added "Visible Distance" into the token settings
- Removed a race condition that resulted in "shiny" or "caught" indicators sometimes being duplicated
- Fixed the Pokerole summon animation